### PR TITLE
Debug frontend deployment showing blank page

### DIFF
--- a/frontend/src/state/themeStore.ts
+++ b/frontend/src/state/themeStore.ts
@@ -72,9 +72,12 @@ export const useThemeStore = create<ThemeState>()(
         if (state) {
           // Recalculate resolved theme after hydration
           const resolved = resolveTheme(state.themeMode);
-          state.resolvedTheme = resolved;
-          state.colors = getColors(resolved);
-          state.isHydrated = true;
+          // Must use setState to trigger React re-renders (direct mutation won't work)
+          useThemeStore.setState({
+            resolvedTheme: resolved,
+            colors: getColors(resolved),
+            isHydrated: true,
+          });
         }
       },
     }


### PR DESCRIPTION
The onRehydrateStorage callback was directly mutating the state object instead of using setState(). This caused isHydrated to remain false from React's perspective, keeping the app stuck on the loading screen.