### PR TITLE
Fix blank white screen after login changes

### DIFF
--- a/frontend/src/state/themeStore.ts
+++ b/frontend/src/state/themeStore.ts
@@ -75,6 +75,9 @@ export const useThemeStore = create<ThemeState>()(
           state.resolvedTheme = resolved;
           state.colors = getColors(resolved);
           state.isHydrated = true;
+        } else {
+          // First run or storage empty - mark as hydrated with defaults
+          useThemeStore.setState({ isHydrated: true });
         }
       },
     }


### PR DESCRIPTION
When AsyncStorage is empty (first run) or fails, the onRehydrateStorage callback receives undefined state. Previously, isHydrated was only set to true when state existed, causing ThemeProvider to show a loading spinner indefinitely. Now we also set isHydrated=true for the undefined case so the app can proceed with default theme values.