### PR TITLE
Debug and identify issues

### DIFF
--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -27,6 +27,20 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "learning_paths",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "lastAccessedAt",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
The listLearningPaths handler queries with Where("userId") and OrderBy("lastAccessedAt", Desc), which requires a composite index. This was missing, causing 500 errors on GET /api/learning-paths.