### PR TITLE
Add new domain to CORS configuration

### DIFF
--- a/backend/internal/middleware/cors.go
+++ b/backend/internal/middleware/cors.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Default allowed origins for development and production
-const defaultAllowedOrigins = "http://localhost:3000,http://localhost:8081,http://localhost:19006,https://ishkul.vercel.app"
+const defaultAllowedOrigins = "http://localhost:3000,http://localhost:8081,http://localhost:19006,https://ishkul.vercel.app,https://www.ishkul.org,https://ishkul.org"
 
 // isVercelDomain checks if the origin is a Vercel deployment (production or preview)
 func isVercelDomain(origin string) bool {


### PR DESCRIPTION
Add https://www.ishkul.org and https://ishkul.org to the default allowed origins for the new production domain.