### PR TITLE
Fix unauthorized API authentication error

### DIFF
--- a/scripts/update-backend-env.sh
+++ b/scripts/update-backend-env.sh
@@ -301,16 +301,23 @@ while IFS='=' read -r key value; do
         continue
     fi
 
-    if [[ "$key" == "JWT_SECRET" ]] || [[ "$key" =~ ^_ ]]; then
-        # Handle as secret (these go to Secret Manager)
-        if [[ "$key" == "JWT_SECRET" ]]; then
-            SECRETS_FLAGS="$SECRETS_FLAGS --set-secrets=JWT_SECRET=${JWT_SECRET_NAME}:latest"
-        fi
+    # Skip JWT_SECRET here - we always mount it from Secret Manager below
+    if [[ "$key" == "JWT_SECRET" ]]; then
+        continue
+    fi
+
+    if [[ "$key" =~ ^_ ]]; then
+        # Handle underscore-prefixed vars as secrets (future use)
+        continue
     else
         # Write to YAML file (properly handles URLs and special characters)
         echo "${key}: \"${value}\"" >> "$ENV_YAML_FILE"
     fi
 done < "$ENV_VARS_FILE"
+
+# Always mount JWT_SECRET from Secret Manager (regardless of whether it's in .env)
+# This ensures the secret is available even if user didn't add it to .env
+SECRETS_FLAGS="--set-secrets=JWT_SECRET=${JWT_SECRET_NAME}:latest"
 
 # Execute the update command using env-vars-file for proper handling of special chars
 gcloud run services update $SERVICE_NAME \


### PR DESCRIPTION
The script was only adding the --set-secrets flag when JWT_SECRET was present in the .env file. This caused a bug where:

1. If JWT_SECRET wasn't in .env, the secret would be created/used in Secret Manager but never mounted to Cloud Run
2. Cloud Run would fall back to generating a random JWT secret
3. Each container restart would generate a new secret, invalidating all existing tokens and causing 401 errors

This fix ensures JWT_SECRET is always mounted from Secret Manager regardless of whether it's explicitly listed in .env.