### PR TITLE
Fix missing prompt template file error

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,12 +6,12 @@ WORKDIR /app
 # Install build dependencies
 RUN apk add --no-cache git
 
-# Copy go mod files
-COPY go.mod go.sum ./
+# Copy go mod files (from backend/ since build context is now project root)
+COPY backend/go.mod backend/go.sum ./
 RUN go mod download
 
-# Copy source code
-COPY . .
+# Copy backend source code
+COPY backend/ ./
 
 # Build the application with verbose output
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -a -installsuffix cgo -o server ./cmd/server
@@ -28,6 +28,9 @@ WORKDIR /app
 
 # Copy binary from builder
 COPY --from=builder /app/server /app/server
+
+# Copy prompts directory (from project root since build context is now root)
+COPY prompts/ /app/prompts/
 
 # Give executable permissions
 RUN chmod +x /app/server

--- a/backend/cloudbuild.yaml
+++ b/backend/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  # Build the Docker image
+  # Build the Docker image from root context to include prompts/
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
@@ -8,9 +8,8 @@ steps:
       - '-t'
       - 'gcr.io/$PROJECT_ID/ishkul-backend:latest'
       - '-f'
-      - 'Dockerfile'
+      - 'backend/Dockerfile'
       - '.'
-    dir: 'backend'
 
   # Push the image to Artifact Registry
   - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
The backend was failing to load prompt templates because the prompts/ directory was not included in the Docker build context. Updated:
- cloudbuild.yaml: build from project root instead of backend/ dir
- Dockerfile: copy from backend/ subdir and include prompts/ in image

Fixes: failed to load prompt template: failed to read prompt file prompts/learning/next-step.prompt.yml