### PR TITLE
Fix unresponsive free plan subscription button

### DIFF
--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -63,7 +63,19 @@ const LearnStack = () => {
       <Stack.Screen name="Lesson" component={LessonScreen} />
       <Stack.Screen name="Quiz" component={QuizScreen} />
       <Stack.Screen name="Practice" component={PracticeScreen} />
-      {/* Subscription management */}
+    </Stack.Navigator>
+  );
+};
+
+// Settings Stack Navigator
+const SettingsStack = () => {
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        headerShown: false,
+      }}
+    >
+      <Stack.Screen name="Settings" component={SettingsScreen} />
       <Stack.Screen name="Subscription" component={SubscriptionScreen} />
     </Stack.Navigator>
   );
@@ -110,9 +122,10 @@ const MainTabs = () => {
         }}
       />
       <Tab.Screen
-        name="Settings"
-        component={SettingsScreen}
+        name="SettingsTab"
+        component={SettingsStack}
         options={{
+          tabBarLabel: 'Settings',
           tabBarIcon: () => (
             <Text style={{ fontSize: 24 }}>⚙️</Text>
           ),

--- a/frontend/src/types/navigation.ts
+++ b/frontend/src/types/navigation.ts
@@ -23,6 +23,7 @@ export type RootStackParamList = {
   StepDetail: { step: Step; pathId: string };
   Progress: undefined;
   Settings: undefined;
+  SettingsTab: undefined;
   // Subscription management
   Subscription: undefined;
 };


### PR DESCRIPTION
The subscription button in Settings was not working because the Subscription screen was in the LearnStack navigator while Settings was a direct tab screen. Created a SettingsStack navigator that includes both Settings and Subscription screens so navigation works.