### PR TITLE
Fix console errors in frontend tests

### DIFF
--- a/frontend/src/screens/__tests__/GoalSelectionScreen.test.tsx
+++ b/frontend/src/screens/__tests__/GoalSelectionScreen.test.tsx
@@ -5,6 +5,49 @@ import { RouteProp } from '@react-navigation/native';
 import { GoalSelectionScreen } from '../GoalSelectionScreen';
 import { RootStackParamList } from '../../types/navigation';
 
+// Mock analytics hooks to prevent console.log outputs
+jest.mock('../../services/analytics/hooks', () => ({
+  useAnalytics: () => ({
+    trackScreen: jest.fn(),
+    setUserId: jest.fn(),
+    setUserProperties: jest.fn(),
+    trackSignUp: jest.fn(),
+    trackLogin: jest.fn(),
+    trackLogout: jest.fn(),
+    trackOnboardingStart: jest.fn(),
+    trackGoalSelected: jest.fn(),
+    trackLevelSelected: jest.fn(),
+    trackOnboardingComplete: jest.fn(),
+    trackLearningPathCreated: jest.fn(),
+    trackLearningPathOpened: jest.fn(),
+    trackLearningPathDeleted: jest.fn(),
+    trackStepStarted: jest.fn(),
+    trackStepCompleted: jest.fn(),
+    trackLessonCompleted: jest.fn(),
+    trackPracticeCompleted: jest.fn(),
+    trackQuizStarted: jest.fn(),
+    trackQuizQuestionAnswered: jest.fn(),
+    trackQuizCompleted: jest.fn(),
+    trackNextStepRequested: jest.fn(),
+    trackNextStepGenerated: jest.fn(),
+    trackAIError: jest.fn(),
+    trackAppOpen: jest.fn(),
+    startSession: jest.fn(),
+    endSession: jest.fn(),
+    trackThemeChanged: jest.fn(),
+    trackProgressViewed: jest.fn(),
+    trackDeleteAccountInitiated: jest.fn(),
+    getActiveTime: jest.fn(),
+  }),
+  useScreenTracking: jest.fn(),
+  useOnboardingTracking: () => ({
+    startOnboarding: jest.fn(),
+    selectGoal: jest.fn(),
+    selectLevel: jest.fn(),
+    completeOnboarding: jest.fn(),
+  }),
+}));
+
 type GoalSelectionScreenNavigationProp = NativeStackNavigationProp<RootStackParamList, 'GoalSelection'>;
 type GoalSelectionScreenRouteProp = RouteProp<RootStackParamList, 'GoalSelection'>;
 

--- a/frontend/src/screens/__tests__/LearningPathScreen.test.tsx
+++ b/frontend/src/screens/__tests__/LearningPathScreen.test.tsx
@@ -44,6 +44,13 @@ const createMockPath = (overrides: Partial<LearningPath> = {}): LearningPath => 
   ...overrides,
 });
 
+// Spy on console.error to suppress expected error logs during tests
+const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+afterAll(() => {
+  consoleErrorSpy.mockRestore();
+});
+
 // Mock stores
 const mockSetActivePath = jest.fn();
 const mockAddStep = jest.fn();
@@ -51,15 +58,30 @@ const mockGetCachedPath = jest.fn();
 const mockIsCacheValid = jest.fn();
 let mockActivePath: LearningPath | null = null;
 
+// Create a mock store object with getState function
+const mockStore = {
+  activePath: null as LearningPath | null,
+  setActivePath: mockSetActivePath,
+  addStep: mockAddStep,
+  getCachedPath: mockGetCachedPath,
+  pathsCache: new Map(),
+  isCacheValid: mockIsCacheValid,
+};
+
 jest.mock('../../state/learningPathsStore', () => ({
-  useLearningPathsStore: () => ({
-    activePath: mockActivePath,
-    setActivePath: mockSetActivePath,
-    addStep: mockAddStep,
-    getCachedPath: mockGetCachedPath,
-    pathsCache: new Map(),
-    isCacheValid: mockIsCacheValid,
-  }),
+  useLearningPathsStore: Object.assign(
+    () => ({
+      activePath: mockActivePath,
+      setActivePath: mockSetActivePath,
+      addStep: mockAddStep,
+      getCachedPath: mockGetCachedPath,
+      pathsCache: new Map(),
+      isCacheValid: mockIsCacheValid,
+    }),
+    {
+      getState: () => mockStore,
+    }
+  ),
   getCurrentStep: jest.fn((steps: Step[]) => steps.find((s) => !s.completed) || null),
 }));
 

--- a/frontend/src/screens/__tests__/LessonScreen.test.tsx
+++ b/frontend/src/screens/__tests__/LessonScreen.test.tsx
@@ -6,8 +6,61 @@ import type { RouteProp } from '@react-navigation/native';
 import { LessonScreen } from '../LessonScreen';
 import type { RootStackParamList } from '../../types/navigation';
 
+// Mock analytics hooks to prevent console.log outputs
+jest.mock('../../services/analytics/hooks', () => ({
+  useAnalytics: () => ({
+    trackScreen: jest.fn(),
+    setUserId: jest.fn(),
+    setUserProperties: jest.fn(),
+    trackSignUp: jest.fn(),
+    trackLogin: jest.fn(),
+    trackLogout: jest.fn(),
+    trackOnboardingStart: jest.fn(),
+    trackGoalSelected: jest.fn(),
+    trackLevelSelected: jest.fn(),
+    trackOnboardingComplete: jest.fn(),
+    trackLearningPathCreated: jest.fn(),
+    trackLearningPathOpened: jest.fn(),
+    trackLearningPathDeleted: jest.fn(),
+    trackStepStarted: jest.fn(),
+    trackStepCompleted: jest.fn(),
+    trackLessonCompleted: jest.fn(),
+    trackPracticeCompleted: jest.fn(),
+    trackQuizStarted: jest.fn(),
+    trackQuizQuestionAnswered: jest.fn(),
+    trackQuizCompleted: jest.fn(),
+    trackNextStepRequested: jest.fn(),
+    trackNextStepGenerated: jest.fn(),
+    trackAIError: jest.fn(),
+    trackAppOpen: jest.fn(),
+    startSession: jest.fn(),
+    endSession: jest.fn(),
+    trackThemeChanged: jest.fn(),
+    trackProgressViewed: jest.fn(),
+    trackDeleteAccountInitiated: jest.fn(),
+    getActiveTime: jest.fn(),
+  }),
+  useScreenTracking: jest.fn(),
+  useActiveTime: () => ({
+    getActiveSeconds: jest.fn().mockReturnValue(0),
+    resetTimer: jest.fn(),
+  }),
+  useStepTracking: () => ({
+    startStep: jest.fn(),
+    completeStep: jest.fn().mockResolvedValue(undefined),
+    getActiveSeconds: jest.fn().mockReturnValue(0),
+  }),
+}));
+
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'Lesson'>;
 type ScreenRouteProp = RouteProp<RootStackParamList, 'Lesson'>;
+
+// Spy on console.error to suppress expected error logs during tests
+const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+afterAll(() => {
+  consoleErrorSpy.mockRestore();
+});
 
 // Mock Alert
 jest.spyOn(Alert, 'alert');

--- a/frontend/src/screens/__tests__/LevelSelectionScreen.test.tsx
+++ b/frontend/src/screens/__tests__/LevelSelectionScreen.test.tsx
@@ -6,8 +6,80 @@ import type { RouteProp } from '@react-navigation/native';
 import { LevelSelectionScreen } from '../LevelSelectionScreen';
 import type { RootStackParamList } from '../../types/navigation';
 
+// Mock analytics hooks to prevent console.log outputs
+jest.mock('../../services/analytics/hooks', () => ({
+  useAnalytics: () => ({
+    trackScreen: jest.fn(),
+    setUserId: jest.fn(),
+    setUserProperties: jest.fn(),
+    trackSignUp: jest.fn(),
+    trackLogin: jest.fn(),
+    trackLogout: jest.fn(),
+    trackOnboardingStart: jest.fn(),
+    trackGoalSelected: jest.fn(),
+    trackLevelSelected: jest.fn(),
+    trackOnboardingComplete: jest.fn(),
+    trackLearningPathCreated: jest.fn(),
+    trackLearningPathOpened: jest.fn(),
+    trackLearningPathDeleted: jest.fn(),
+    trackStepStarted: jest.fn(),
+    trackStepCompleted: jest.fn(),
+    trackLessonCompleted: jest.fn(),
+    trackPracticeCompleted: jest.fn(),
+    trackQuizStarted: jest.fn(),
+    trackQuizQuestionAnswered: jest.fn(),
+    trackQuizCompleted: jest.fn(),
+    trackNextStepRequested: jest.fn(),
+    trackNextStepGenerated: jest.fn(),
+    trackAIError: jest.fn(),
+    trackAppOpen: jest.fn(),
+    startSession: jest.fn(),
+    endSession: jest.fn(),
+    trackThemeChanged: jest.fn(),
+    trackProgressViewed: jest.fn(),
+    trackDeleteAccountInitiated: jest.fn(),
+    getActiveTime: jest.fn(),
+  }),
+  useScreenTracking: jest.fn(),
+  useActiveTime: () => ({
+    getActiveSeconds: jest.fn().mockReturnValue(0),
+    resetTimer: jest.fn(),
+  }),
+  useStepTracking: () => ({
+    startStep: jest.fn(),
+    completeStep: jest.fn(),
+    getActiveSeconds: jest.fn().mockReturnValue(0),
+  }),
+  useQuizTracking: () => ({
+    startQuiz: jest.fn(),
+    answerQuestion: jest.fn(),
+    completeQuiz: jest.fn(),
+    getActiveSeconds: jest.fn().mockReturnValue(0),
+  }),
+  useOnboardingTracking: () => ({
+    startOnboarding: jest.fn(),
+    selectGoal: jest.fn(),
+    selectLevel: jest.fn(),
+    completeOnboarding: jest.fn(),
+  }),
+  useAITracking: () => ({
+    startRequest: jest.fn(),
+    completeRequest: jest.fn(),
+    trackError: jest.fn(),
+  }),
+  useSessionTracking: jest.fn(),
+  useThemeTracking: jest.fn(),
+}));
+
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'LevelSelection'>;
 type ScreenRouteProp = RouteProp<RootStackParamList, 'LevelSelection'>;
+
+// Spy on console.error to suppress expected error logs during tests
+const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+afterAll(() => {
+  consoleErrorSpy.mockRestore();
+});
 
 // Mock Alert
 jest.spyOn(Alert, 'alert');

--- a/frontend/src/screens/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/screens/__tests__/PracticeScreen.test.tsx
@@ -6,8 +6,61 @@ import type { RouteProp } from '@react-navigation/native';
 import { PracticeScreen } from '../PracticeScreen';
 import type { RootStackParamList } from '../../types/navigation';
 
+// Mock analytics hooks to prevent console.log outputs
+jest.mock('../../services/analytics/hooks', () => ({
+  useAnalytics: () => ({
+    trackScreen: jest.fn(),
+    setUserId: jest.fn(),
+    setUserProperties: jest.fn(),
+    trackSignUp: jest.fn(),
+    trackLogin: jest.fn(),
+    trackLogout: jest.fn(),
+    trackOnboardingStart: jest.fn(),
+    trackGoalSelected: jest.fn(),
+    trackLevelSelected: jest.fn(),
+    trackOnboardingComplete: jest.fn(),
+    trackLearningPathCreated: jest.fn(),
+    trackLearningPathOpened: jest.fn(),
+    trackLearningPathDeleted: jest.fn(),
+    trackStepStarted: jest.fn(),
+    trackStepCompleted: jest.fn(),
+    trackLessonCompleted: jest.fn(),
+    trackPracticeCompleted: jest.fn(),
+    trackQuizStarted: jest.fn(),
+    trackQuizQuestionAnswered: jest.fn(),
+    trackQuizCompleted: jest.fn(),
+    trackNextStepRequested: jest.fn(),
+    trackNextStepGenerated: jest.fn(),
+    trackAIError: jest.fn(),
+    trackAppOpen: jest.fn(),
+    startSession: jest.fn(),
+    endSession: jest.fn(),
+    trackThemeChanged: jest.fn(),
+    trackProgressViewed: jest.fn(),
+    trackDeleteAccountInitiated: jest.fn(),
+    getActiveTime: jest.fn(),
+  }),
+  useScreenTracking: jest.fn(),
+  useActiveTime: () => ({
+    getActiveSeconds: jest.fn().mockReturnValue(0),
+    resetTimer: jest.fn(),
+  }),
+  useStepTracking: () => ({
+    startStep: jest.fn(),
+    completeStep: jest.fn().mockResolvedValue(undefined),
+    getActiveSeconds: jest.fn().mockReturnValue(0),
+  }),
+}));
+
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'Practice'>;
 type ScreenRouteProp = RouteProp<RootStackParamList, 'Practice'>;
+
+// Spy on console.error to suppress expected error logs during tests
+const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+afterAll(() => {
+  consoleErrorSpy.mockRestore();
+});
 
 // Mock Alert
 jest.spyOn(Alert, 'alert');

--- a/frontend/src/screens/__tests__/ProgressScreen.test.tsx
+++ b/frontend/src/screens/__tests__/ProgressScreen.test.tsx
@@ -3,6 +3,71 @@ import { render } from '@testing-library/react-native';
 import { ProgressScreen } from '../ProgressScreen';
 import { UserDocument } from '../../types/app';
 
+// Mock analytics hooks to prevent console.log outputs
+jest.mock('../../services/analytics/hooks', () => ({
+  useAnalytics: () => ({
+    trackScreen: jest.fn(),
+    setUserId: jest.fn(),
+    setUserProperties: jest.fn(),
+    trackSignUp: jest.fn(),
+    trackLogin: jest.fn(),
+    trackLogout: jest.fn(),
+    trackOnboardingStart: jest.fn(),
+    trackGoalSelected: jest.fn(),
+    trackLevelSelected: jest.fn(),
+    trackOnboardingComplete: jest.fn(),
+    trackLearningPathCreated: jest.fn(),
+    trackLearningPathOpened: jest.fn(),
+    trackLearningPathDeleted: jest.fn(),
+    trackStepStarted: jest.fn(),
+    trackStepCompleted: jest.fn(),
+    trackLessonCompleted: jest.fn(),
+    trackPracticeCompleted: jest.fn(),
+    trackQuizStarted: jest.fn(),
+    trackQuizQuestionAnswered: jest.fn(),
+    trackQuizCompleted: jest.fn(),
+    trackNextStepRequested: jest.fn(),
+    trackNextStepGenerated: jest.fn(),
+    trackAIError: jest.fn(),
+    trackAppOpen: jest.fn(),
+    startSession: jest.fn(),
+    endSession: jest.fn(),
+    trackThemeChanged: jest.fn(),
+    trackProgressViewed: jest.fn(),
+    trackDeleteAccountInitiated: jest.fn(),
+    getActiveTime: jest.fn(),
+  }),
+  useScreenTracking: jest.fn(),
+  useActiveTime: () => ({
+    getActiveSeconds: jest.fn().mockReturnValue(0),
+    resetTimer: jest.fn(),
+  }),
+  useStepTracking: () => ({
+    startStep: jest.fn(),
+    completeStep: jest.fn(),
+    getActiveSeconds: jest.fn().mockReturnValue(0),
+  }),
+  useQuizTracking: () => ({
+    startQuiz: jest.fn(),
+    answerQuestion: jest.fn(),
+    completeQuiz: jest.fn(),
+    getActiveSeconds: jest.fn().mockReturnValue(0),
+  }),
+  useOnboardingTracking: () => ({
+    startOnboarding: jest.fn(),
+    selectGoal: jest.fn(),
+    selectLevel: jest.fn(),
+    completeOnboarding: jest.fn(),
+  }),
+  useAITracking: () => ({
+    startRequest: jest.fn(),
+    completeRequest: jest.fn(),
+    trackError: jest.fn(),
+  }),
+  useSessionTracking: jest.fn(),
+  useThemeTracking: jest.fn(),
+}));
+
 // Mock userStore
 let mockUserDocument: UserDocument | null = null;
 jest.mock('../../state/userStore', () => ({

--- a/frontend/src/screens/__tests__/QuizScreen.test.tsx
+++ b/frontend/src/screens/__tests__/QuizScreen.test.tsx
@@ -6,13 +6,7 @@ import type { RouteProp } from '@react-navigation/native';
 import { QuizScreen } from '../QuizScreen';
 import type { RootStackParamList } from '../../types/navigation';
 
-type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'Quiz'>;
-type ScreenRouteProp = RouteProp<RootStackParamList, 'Quiz'>;
-
-// Mock Alert
-jest.spyOn(Alert, 'alert');
-
-// Mock analytics hooks
+// Mock analytics hooks to prevent console.log outputs
 const mockStartQuiz = jest.fn();
 const mockAnswerQuestion = jest.fn().mockResolvedValue(undefined);
 const mockCompleteQuiz = jest.fn().mockResolvedValue(undefined);
@@ -25,6 +19,19 @@ jest.mock('../../services/analytics', () => ({
     getActiveSeconds: jest.fn().mockReturnValue(0),
   }),
 }));
+
+type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'Quiz'>;
+type ScreenRouteProp = RouteProp<RootStackParamList, 'Quiz'>;
+
+// Spy on console.error to suppress expected error logs during tests
+const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+afterAll(() => {
+  consoleErrorSpy.mockRestore();
+});
+
+// Mock Alert
+jest.spyOn(Alert, 'alert');
 
 // Mock userStore
 const mockSetUserDocument = jest.fn();

--- a/frontend/src/screens/__tests__/SettingsScreen.test.tsx
+++ b/frontend/src/screens/__tests__/SettingsScreen.test.tsx
@@ -4,6 +4,26 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { SettingsScreen } from '../SettingsScreen';
 import type { RootStackParamList } from '../../types/navigation';
 
+// Mock analytics hooks to prevent console.log outputs
+jest.mock('../../services/analytics/hooks', () => ({
+  useAnalytics: () => ({
+    trackScreen: jest.fn(),
+    setUserId: jest.fn(),
+    setUserProperties: jest.fn(),
+    trackThemeChanged: jest.fn(),
+    trackDeleteAccountInitiated: jest.fn(),
+  }),
+  useScreenTracking: jest.fn(),
+  useThemeTracking: jest.fn(),
+}));
+
+// Spy on console.error to suppress expected error logs during tests
+const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+afterAll(() => {
+  consoleErrorSpy.mockRestore();
+});
+
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'Settings'>;
 
 // Mock userStore

--- a/frontend/src/services/__tests__/llmEngine.test.ts
+++ b/frontend/src/services/__tests__/llmEngine.test.ts
@@ -38,11 +38,18 @@ const mockDefaultStep = {
 };
 
 describe('llmEngine', () => {
+  // Spy on console.error to suppress expected error logs during tests
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
   beforeEach(() => {
     jest.clearAllMocks();
     // Reset authApi mock to return valid token for each test
     const { authApi } = require('../api');
     authApi.getAccessToken.mockReturnValue('test-token');
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   describe('getNextStep', () => {

--- a/frontend/src/state/__tests__/subscriptionStore.test.ts
+++ b/frontend/src/state/__tests__/subscriptionStore.test.ts
@@ -25,6 +25,13 @@ jest.mock('react-native', () => ({
 }));
 
 describe('subscriptionStore', () => {
+  // Spy on console.error to suppress expected error logs during tests
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
   beforeEach(() => {
     // Reset the store state before each test
     useSubscriptionStore.setState({


### PR DESCRIPTION
- Add console.error spy to tests that verify error handling behavior
- Mock analytics hooks in screen tests to prevent debug log outputs
- Fix LearningPathScreen test mock to include getState method

All 417 tests now pass without any console noise from expected error scenarios and analytics debug logs during test execution.