### PR TITLE
Find and fix security vulnerabilities

### DIFF
--- a/backend/internal/handlers/learning_paths.go
+++ b/backend/internal/handlers/learning_paths.go
@@ -238,7 +238,7 @@ func listLearningPaths(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 		if err != nil {
-			http.Error(w, fmt.Sprintf("Error fetching learning paths: %v", err), http.StatusInternalServerError)
+			http.Error(w, "Error fetching learning paths", http.StatusInternalServerError)
 			return
 		}
 
@@ -287,13 +287,13 @@ func getLearningPath(w http.ResponseWriter, r *http.Request, pathID string) {
 
 	doc, err := fs.Collection("learning_paths").Doc(pathID).Get(ctx)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Learning path not found: %v", err), http.StatusNotFound)
+		http.Error(w, "Learning path not found", http.StatusNotFound)
 		return
 	}
 
 	var path models.LearningPath
 	if err := doc.DataTo(&path); err != nil {
-		http.Error(w, fmt.Sprintf("Error reading learning path: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error reading learning path", http.StatusInternalServerError)
 		return
 	}
 
@@ -333,7 +333,7 @@ func createLearningPath(w http.ResponseWriter, r *http.Request) {
 
 	var req models.LearningPathCreate
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, fmt.Sprintf("Invalid request body: %v", err), http.StatusBadRequest)
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
 
@@ -358,7 +358,7 @@ func createLearningPath(w http.ResponseWriter, r *http.Request) {
 	// Check if user has reached the maximum number of learning paths for their tier
 	existingPaths, err := CountUserActivePaths(ctx, fs, userID)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Error checking existing paths: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error checking existing paths", http.StatusInternalServerError)
 		return
 	}
 
@@ -404,7 +404,7 @@ func createLearningPath(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err := fs.Collection("learning_paths").Doc(pathID).Set(ctx, path); err != nil {
-		http.Error(w, fmt.Sprintf("Error creating learning path: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error creating learning path", http.StatusInternalServerError)
 		return
 	}
 
@@ -521,13 +521,13 @@ func updateLearningPath(w http.ResponseWriter, r *http.Request, pathID string) {
 	// First verify ownership
 	doc, err := fs.Collection("learning_paths").Doc(pathID).Get(ctx)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Learning path not found: %v", err), http.StatusNotFound)
+		http.Error(w, "Learning path not found", http.StatusNotFound)
 		return
 	}
 
 	var existing models.LearningPath
 	if err := doc.DataTo(&existing); err != nil {
-		http.Error(w, fmt.Sprintf("Error reading learning path: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error reading learning path", http.StatusInternalServerError)
 		return
 	}
 
@@ -538,7 +538,7 @@ func updateLearningPath(w http.ResponseWriter, r *http.Request, pathID string) {
 
 	var req models.LearningPathUpdate
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, fmt.Sprintf("Invalid request body: %v", err), http.StatusBadRequest)
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
 
@@ -568,20 +568,20 @@ func updateLearningPath(w http.ResponseWriter, r *http.Request, pathID string) {
 	}
 
 	if _, err := fs.Collection("learning_paths").Doc(pathID).Update(ctx, updates); err != nil {
-		http.Error(w, fmt.Sprintf("Error updating learning path: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error updating learning path", http.StatusInternalServerError)
 		return
 	}
 
 	// Fetch updated document
 	doc, err = fs.Collection("learning_paths").Doc(pathID).Get(ctx)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Error fetching updated path: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error fetching updated path", http.StatusInternalServerError)
 		return
 	}
 
 	var path models.LearningPath
 	if err := doc.DataTo(&path); err != nil {
-		http.Error(w, fmt.Sprintf("Error reading learning path: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error reading learning path", http.StatusInternalServerError)
 		return
 	}
 
@@ -615,13 +615,13 @@ func deleteLearningPath(w http.ResponseWriter, r *http.Request, pathID string) {
 	// First verify ownership
 	doc, err := fs.Collection("learning_paths").Doc(pathID).Get(ctx)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Learning path not found: %v", err), http.StatusNotFound)
+		http.Error(w, "Learning path not found", http.StatusNotFound)
 		return
 	}
 
 	var existing models.LearningPath
 	if err := doc.DataTo(&existing); err != nil {
-		http.Error(w, fmt.Sprintf("Error reading learning path: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error reading learning path", http.StatusInternalServerError)
 		return
 	}
 
@@ -645,7 +645,7 @@ func deleteLearningPath(w http.ResponseWriter, r *http.Request, pathID string) {
 	}
 
 	if _, err := fs.Collection("learning_paths").Doc(pathID).Update(ctx, updates); err != nil {
-		http.Error(w, fmt.Sprintf("Error deleting learning path: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error deleting learning path", http.StatusInternalServerError)
 		return
 	}
 
@@ -681,13 +681,13 @@ func archiveLearningPath(w http.ResponseWriter, r *http.Request, pathID string) 
 
 	doc, err := fs.Collection("learning_paths").Doc(pathID).Get(ctx)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Learning path not found: %v", err), http.StatusNotFound)
+		http.Error(w, "Learning path not found", http.StatusNotFound)
 		return
 	}
 
 	var path models.LearningPath
 	if err := doc.DataTo(&path); err != nil {
-		http.Error(w, fmt.Sprintf("Error reading learning path: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error reading learning path", http.StatusInternalServerError)
 		return
 	}
 
@@ -746,13 +746,13 @@ func unarchiveLearningPath(w http.ResponseWriter, r *http.Request, pathID string
 
 	doc, err := fs.Collection("learning_paths").Doc(pathID).Get(ctx)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Learning path not found: %v", err), http.StatusNotFound)
+		http.Error(w, "Learning path not found", http.StatusNotFound)
 		return
 	}
 
 	var path models.LearningPath
 	if err := doc.DataTo(&path); err != nil {
-		http.Error(w, fmt.Sprintf("Error reading learning path: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error reading learning path", http.StatusInternalServerError)
 		return
 	}
 
@@ -864,13 +864,13 @@ func getPathNextStep(w http.ResponseWriter, r *http.Request, pathID string) {
 
 	doc, err := fs.Collection("learning_paths").Doc(pathID).Get(ctx)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Learning path not found: %v", err), http.StatusNotFound)
+		http.Error(w, "Learning path not found", http.StatusNotFound)
 		return
 	}
 
 	var path models.LearningPath
 	if err := doc.DataTo(&path); err != nil {
-		http.Error(w, fmt.Sprintf("Error reading learning path: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error reading learning path", http.StatusInternalServerError)
 		return
 	}
 
@@ -1228,13 +1228,13 @@ func completeCurrentStep(w http.ResponseWriter, r *http.Request, pathID string) 
 
 	doc, err := fs.Collection("learning_paths").Doc(pathID).Get(ctx)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Learning path not found: %v", err), http.StatusNotFound)
+		http.Error(w, "Learning path not found", http.StatusNotFound)
 		return
 	}
 
 	var path models.LearningPath
 	if err := doc.DataTo(&path); err != nil {
-		http.Error(w, fmt.Sprintf("Error reading learning path: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error reading learning path", http.StatusInternalServerError)
 		return
 	}
 
@@ -1278,13 +1278,13 @@ func completeStep(w http.ResponseWriter, r *http.Request, pathID string, stepID 
 
 	doc, err := fs.Collection("learning_paths").Doc(pathID).Get(ctx)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Learning path not found: %v", err), http.StatusNotFound)
+		http.Error(w, "Learning path not found", http.StatusNotFound)
 		return
 	}
 
 	var path models.LearningPath
 	if err := doc.DataTo(&path); err != nil {
-		http.Error(w, fmt.Sprintf("Error reading learning path: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error reading learning path", http.StatusInternalServerError)
 		return
 	}
 
@@ -1434,19 +1434,19 @@ func completeStepInternal(w http.ResponseWriter, r *http.Request, pathID string,
 	}
 
 	if _, err := fs.Collection("learning_paths").Doc(pathID).Update(ctx, updates); err != nil {
-		http.Error(w, fmt.Sprintf("Error updating learning path: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error updating learning path", http.StatusInternalServerError)
 		return
 	}
 
 	// Fetch updated path
 	doc, err := fs.Collection("learning_paths").Doc(pathID).Get(ctx)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Error fetching updated path: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error fetching updated path", http.StatusInternalServerError)
 		return
 	}
 
 	if err := doc.DataTo(path); err != nil {
-		http.Error(w, fmt.Sprintf("Error reading learning path: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error reading learning path", http.StatusInternalServerError)
 		return
 	}
 
@@ -1530,13 +1530,13 @@ func viewStep(w http.ResponseWriter, r *http.Request, pathID string, stepID stri
 
 	doc, err := fs.Collection("learning_paths").Doc(pathID).Get(ctx)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Learning path not found: %v", err), http.StatusNotFound)
+		http.Error(w, "Learning path not found", http.StatusNotFound)
 		return
 	}
 
 	var path models.LearningPath
 	if err := doc.DataTo(&path); err != nil {
-		http.Error(w, fmt.Sprintf("Error reading learning path: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error reading learning path", http.StatusInternalServerError)
 		return
 	}
 
@@ -1815,7 +1815,7 @@ func updatePathMemory(w http.ResponseWriter, r *http.Request, pathID string) {
 
 	var req UpdatePathMemoryRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, fmt.Sprintf("Invalid request body: %v", err), http.StatusBadRequest)
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
 
@@ -1833,13 +1833,13 @@ func updatePathMemory(w http.ResponseWriter, r *http.Request, pathID string) {
 	// Verify ownership
 	doc, err := fs.Collection("learning_paths").Doc(pathID).Get(ctx)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Learning path not found: %v", err), http.StatusNotFound)
+		http.Error(w, "Learning path not found", http.StatusNotFound)
 		return
 	}
 
 	var path models.LearningPath
 	if err := doc.DataTo(&path); err != nil {
-		http.Error(w, fmt.Sprintf("Error reading learning path: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Error reading learning path", http.StatusInternalServerError)
 		return
 	}
 

--- a/backend/internal/middleware/bodylimit.go
+++ b/backend/internal/middleware/bodylimit.go
@@ -1,0 +1,32 @@
+package middleware
+
+import (
+	"net/http"
+)
+
+// MaxBodySize is the default maximum request body size (10 MB)
+// This prevents denial of service attacks via large request payloads
+const MaxBodySize = 10 * 1024 * 1024 // 10 MB
+
+// BodyLimit middleware limits the size of request bodies to prevent DoS attacks
+// It wraps the request body with http.MaxBytesReader which returns an error
+// if the body exceeds the specified limit
+func BodyLimit(next http.Handler) http.Handler {
+	return BodyLimitWithSize(next, MaxBodySize)
+}
+
+// BodyLimitWithSize middleware limits the size of request bodies to a custom size
+func BodyLimitWithSize(next http.Handler, maxBytes int64) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Skip body limit for requests without a body
+		if r.Body == nil || r.ContentLength == 0 {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Wrap the body with a size limiter
+		r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -1,10 +1,14 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    // Users collection
+    // Users collection - users can only read/write their own documents
     match /users/{userId} {
-      allow read: if request.auth != null;
-      allow write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+
+      // Subcollections under user (e.g., usage)
+      match /{subcollection}/{document=**} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
     }
 
     // Progress collection


### PR DESCRIPTION
Security fixes included:
- Add URL validation for Stripe redirect URLs to prevent open redirect attacks
- Remove weak Google token validation fallback that accepted tokens without audience verification
- Fix Firestore rules to only allow users to read their own documents
- Add request body size limit middleware (10 MB) to prevent DoS attacks
- Add MaxHeaderBytes (1 MB) to HTTP server config
- Remove internal error details from HTTP responses to prevent information disclosure

Files changed:
- backend/internal/handlers/subscription.go: Add isValidRedirectURL validation
- backend/internal/handlers/auth.go: Require Google client ID configuration
- backend/internal/handlers/learning_paths.go: Remove error details from responses
- backend/internal/middleware/bodylimit.go: New body size limit middleware
- backend/cmd/server/main.go: Apply body limit middleware and MaxHeaderBytes
- firebase/firestore.rules: Restrict user document access to owner only