### PR TITLE
Release version 1.0.1 to production

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   update-prod-branch:
     name: Update prod branch


### PR DESCRIPTION
The release workflow was failing with a 403 error because the GITHUB_TOKEN didn't have write permissions to push to the prod branch. Added `permissions: contents: write` to grant the necessary access.