### PR TITLE
Fix React Server Components RCE vulnerability

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13932,9 +13932,9 @@
       }
     },
     "node_modules/react-server-dom-webpack": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-server-dom-webpack/-/react-server-dom-webpack-19.0.0.tgz",
-      "integrity": "sha512-hLug9KEXLc8vnU9lDNe2b2rKKDaqrp5gNiES4uyu2Up3FZfZJZmdwLFXlWzdA9gTB/6/cWduSB2K1Lfag2pSvw==",
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/react-server-dom-webpack/-/react-server-dom-webpack-19.0.1.tgz",
+      "integrity": "sha512-RdiENR3uo87Te0jZbFcCLX1chzpwFGLqN35h7n5pgGNiXqWnz43ly94uyCiy4X8zx3swjYYULHmJvwK1P5HBig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13946,8 +13946,8 @@
         "node": ">=0.10.0"
       },
       "peerDependencies": {
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
+        "react": "^19.0.1",
+        "react-dom": "^19.0.1",
         "webpack": "^5.59.0"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,8 @@
     "typescript": "~5.9.2"
   },
   "overrides": {
-    "markdown-it": ">=12.3.2"
+    "markdown-it": ">=12.3.2",
+    "react-server-dom-webpack": "19.0.1"
   },
   "private": true
 }


### PR DESCRIPTION
…ebpack

Override react-server-dom-webpack to 19.0.1 to fix CVE-2025-55182, a critical (CVSS 10.0) unauthenticated remote code execution vulnerability in React Server Components.

The vulnerable package was a transitive dependency from jest-expo.