### PR TITLE
Add delete and archive buttons for learning

### DIFF
--- a/frontend/src/services/memory.ts
+++ b/frontend/src/services/memory.ts
@@ -84,6 +84,20 @@ export const deleteLearningPath = async (pathId: string): Promise<void> => {
 };
 
 /**
+ * Archive a learning path
+ */
+export const archiveLearningPath = async (pathId: string): Promise<LearningPath> => {
+  return learningPathsApi.archivePath(pathId);
+};
+
+/**
+ * Restore an archived learning path
+ */
+export const restoreLearningPath = async (pathId: string): Promise<LearningPath> => {
+  return learningPathsApi.restorePath(pathId);
+};
+
+/**
  * Get next step - returns existing incomplete step or generates new one
  */
 export const getPathNextStep = async (


### PR DESCRIPTION
Add delete and archive buttons to the LearningPathScreen top bar, allowing users to manage their learning paths directly from the path detail view.
- Archive button for active/completed paths (with confirmation dialog)
- Restore button for archived paths
- Delete button with confirmation dialog
- Add archiveLearningPath and restoreLearningPath functions to memory.ts