### PR TITLE
Add reasoning and citation instructions to prompts

### DIFF
--- a/frontend/src/components/MarkdownContent.tsx
+++ b/frontend/src/components/MarkdownContent.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import React, { useMemo } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
 import Markdown from 'react-native-markdown-display';
 import { useTheme } from '../hooks/useTheme';
 import { Typography } from '../theme/typography';
@@ -9,8 +9,37 @@ interface MarkdownContentProps {
   content: string;
 }
 
+interface Citation {
+  id: string;
+  text: string;
+}
+
+/**
+ * Parses citation footnotes from markdown content
+ * Format: [^1]: Source text
+ */
+const parseCitations = (content: string): { cleanContent: string; citations: Citation[] } => {
+  const citations: Citation[] = [];
+  const footnoteRegex = /^\[\^(\d+)\]:\s*(.+)$/gm;
+
+  let match;
+  while ((match = footnoteRegex.exec(content)) !== null) {
+    citations.push({
+      id: match[1],
+      text: match[2].trim(),
+    });
+  }
+
+  // Remove footnote definitions from content (they'll be displayed separately)
+  const cleanContent = content.replace(/^\[\^(\d+)\]:\s*.+$/gm, '').trim();
+
+  return { cleanContent, citations };
+};
+
 export const MarkdownContent: React.FC<MarkdownContentProps> = ({ content }) => {
   const { colors } = useTheme();
+
+  const { cleanContent, citations } = useMemo(() => parseCitations(content), [content]);
 
   const markdownStyles = {
     body: {
@@ -105,9 +134,87 @@ export const MarkdownContent: React.FC<MarkdownContentProps> = ({ content }) => 
     },
   };
 
+  // Custom rules for inline citation references [^1]
+  const rules = {
+    text: (node: { content: string }, children: React.ReactNode, parent: unknown, styles: Record<string, object>) => {
+      const text = node.content;
+      // Check for citation references like [^1]
+      const citationRefRegex = /\[\^(\d+)\]/g;
+
+      if (!citationRefRegex.test(text)) {
+        return <Text key={`text-${text.substring(0, 10)}`} style={styles.text}>{text}</Text>;
+      }
+
+      // Split text by citation references and render with superscript styling
+      const parts: React.ReactNode[] = [];
+      let lastIndex = 0;
+      let match;
+
+      // Reset regex
+      citationRefRegex.lastIndex = 0;
+
+      while ((match = citationRefRegex.exec(text)) !== null) {
+        // Add text before the citation
+        if (match.index > lastIndex) {
+          parts.push(
+            <Text key={`pre-${match.index}`} style={styles.text}>
+              {text.substring(lastIndex, match.index)}
+            </Text>
+          );
+        }
+
+        // Add the citation reference as superscript
+        parts.push(
+          <Text
+            key={`cite-${match[1]}-${match.index}`}
+            style={{
+              fontSize: 10,
+              lineHeight: 14,
+              color: colors.primary,
+              fontWeight: '600' as const,
+            }}
+          >
+            [{match[1]}]
+          </Text>
+        );
+
+        lastIndex = match.index + match[0].length;
+      }
+
+      // Add remaining text
+      if (lastIndex < text.length) {
+        parts.push(
+          <Text key={`post-${lastIndex}`} style={styles.text}>
+            {text.substring(lastIndex)}
+          </Text>
+        );
+      }
+
+      return <Text key={`citation-text-${text.substring(0, 10)}`}>{parts}</Text>;
+    },
+  };
+
   return (
     <View style={styles.container}>
-      <Markdown style={markdownStyles}>{content}</Markdown>
+      <Markdown style={markdownStyles} rules={rules}>{cleanContent}</Markdown>
+
+      {citations.length > 0 && (
+        <View style={[styles.citationsContainer, { borderTopColor: colors.border }]}>
+          <Text style={[styles.citationsHeader, { color: colors.text.secondary }]}>
+            Sources
+          </Text>
+          {citations.map((citation) => (
+            <View key={citation.id} style={styles.citationItem}>
+              <Text style={[styles.citationNumber, { color: colors.primary }]}>
+                [{citation.id}]
+              </Text>
+              <Text style={[styles.citationText, { color: colors.text.secondary }]}>
+                {citation.text}
+              </Text>
+            </View>
+          ))}
+        </View>
+      )}
     </View>
   );
 };
@@ -115,5 +222,33 @@ export const MarkdownContent: React.FC<MarkdownContentProps> = ({ content }) => 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  citationsContainer: {
+    marginTop: Spacing.lg,
+    paddingTop: Spacing.md,
+    borderTopWidth: 1,
+  },
+  citationsHeader: {
+    fontSize: Typography.body.small.fontSize,
+    fontWeight: '600',
+    marginBottom: Spacing.sm,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  citationItem: {
+    flexDirection: 'row',
+    marginBottom: Spacing.xs,
+    paddingLeft: Spacing.sm,
+  },
+  citationNumber: {
+    fontSize: Typography.body.small.fontSize,
+    fontWeight: '600',
+    marginRight: Spacing.xs,
+    minWidth: 24,
+  },
+  citationText: {
+    fontSize: Typography.body.small.fontSize,
+    flex: 1,
+    lineHeight: 18,
   },
 });

--- a/prompts/learning/course-outline.prompt.yml
+++ b/prompts/learning/course-outline.prompt.yml
@@ -91,6 +91,12 @@ messages:
           "difficulty": "beginner|intermediate|advanced",
           "category": "programming|language|data-science|business|etc",
           "tags": ["tag1", "tag2"]
+        },
+        "reasoning": {
+          "structureRationale": "Why this module ordering makes sense for the learner",
+          "toolChoices": "Key decisions about tool selection and why",
+          "learningProgression": "How topics build on each other",
+          "coverageAnalysis": "What concepts are covered and why this is comprehensive"
         }
       }
 
@@ -102,6 +108,15 @@ messages:
       - Specialized tools used when course category matches
       - Topic titles are specific, not generic
       - Prerequisites form a valid dependency graph
+
+      ## Reasoning About Your Outline
+      Before finalizing, think through and include your reasoning in the response:
+      - **Why this structure?** Explain why you chose this specific module ordering and topic sequence
+      - **Why these tools?** Justify tool selection for key topics (e.g., "Using quiz after X because learner needs to verify understanding before moving to Y")
+      - **Learning path rationale**: Describe how topics build on each other to achieve the learning outcomes
+      - **Gap analysis**: Confirm the outline covers all essential concepts without redundancy
+
+      Include a "reasoning" field in your JSON output that explains your pedagogical decisions.
 
       IMPORTANT: Return ONLY valid JSON. No markdown code blocks, no explanation.
 

--- a/prompts/learning/tools/lesson.prompt.yml
+++ b/prompts/learning/tools/lesson.prompt.yml
@@ -32,6 +32,14 @@ messages:
       - Short sentences (15 words max)
       - Short paragraphs (2-3 sentences)
 
+      ## Citations
+      - Cite sources inline using superscript notation: `[^1]`, `[^2]`, etc.
+      - Include a "Sources" section at the end with full citations
+      - Format: `[^1]: Author/Source Name - "Title" (Year if applicable)`
+      - Cite authoritative sources: official docs, textbooks, research papers
+      - Every factual claim should have a citation where possible
+      - Keep citations concise but attributable
+
       ## Level Adjustments
       - **beginner**: Define terms, use analogies
       - **intermediate**: Skip basics, focus on "how"
@@ -53,6 +61,27 @@ messages:
       **Description**: {{description}}
       **Level**: {{level}}
       **Goal**: {{goal}}
-      **Previous topics**: {{previousTopics}}
+      **Previous topics covered**: {{previousTopics}}
+
+      ## Previous Lessons Context
+      Use this to avoid repeating content and build on what the learner already knows:
+
+      {{#if previousLessons}}
+      {{#each previousLessons}}
+      ### {{this.title}}
+      - **Key concepts taught**: {{this.summary}}
+      - **User performance**: {{this.performance}}
+      - **Avoid repeating**: {{this.keyPoints}}
+      {{/each}}
+      {{else}}
+      No previous lessons in this module yet.
+      {{/if}}
+
+      ## Instructions
+      - Do NOT repeat concepts already covered in previous lessons
+      - Build on the learner's existing knowledge from prior lessons
+      - Reference previous content when relevant (e.g., "As we saw in...")
+      - Adjust depth based on user's past performance
+      - Include inline citations for factual claims
 
       Return ONLY valid JSON. 100-200 words MAX.


### PR DESCRIPTION
…ng and citations

- Add reasoning section to course outline prompt requiring LLM to explain why the outline structure, tool choices, and learning progression are optimal
- Add inline citation instructions to lesson prompt for factual claims
- Add previous lessons context to lesson prompt to prevent content repetition and enable building on learner's existing knowledge
- Update MarkdownContent component to parse and render citations with styled footnotes section